### PR TITLE
Ensure every `AsyncExitStack` will be closed

### DIFF
--- a/src/mahoraga/_conda/__init__.py
+++ b/src/mahoraga/_conda/__init__.py
@@ -16,10 +16,12 @@ __all__ = ["router", "split_repo"]
 
 import fastapi
 
+from mahoraga import _core
+
 from . import _packages, _repodata, _sharded_repodata
 from ._sharded_repodata import split_repo
 
-router = fastapi.APIRouter()
+router = fastapi.APIRouter(route_class=_core.APIRoute)
 router.include_router(_repodata.router)
 router.include_router(_sharded_repodata.router)
 router.include_router(_packages.router)  # Must be the last included

--- a/src/mahoraga/_conda/_repodata.py
+++ b/src/mahoraga/_conda/_repodata.py
@@ -27,7 +27,7 @@ from mahoraga import _core
 
 from . import _models, _utils
 
-router = fastapi.APIRouter()
+router = fastapi.APIRouter(route_class=_core.APIRoute)
 
 
 @router.head("/{channel}/{platform}/repodata.json.bz2")

--- a/src/mahoraga/_conda/_sharded_repodata.py
+++ b/src/mahoraga/_conda/_sharded_repodata.py
@@ -32,7 +32,7 @@ from mahoraga import _core
 
 from . import _models, _utils
 
-router = fastapi.APIRouter()
+router = fastapi.APIRouter(route_class=_core.APIRoute)
 
 
 @router.get("/{channel}/{platform}/repodata_shards.msgpack.zst")

--- a/src/mahoraga/_core/__init__.py
+++ b/src/mahoraga/_core/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 __all__ = [
+    "APIRoute",
     "AsyncClient",
-    "AsyncExitStack",
     "Config",
     "Doc",
     "Predicate",
@@ -25,6 +25,7 @@ __all__ = [
     "WeakValueDictionary",
     "context",
     "get",
+    "schedule_exit",
     "stream",
     "unreachable",
 ]
@@ -34,12 +35,12 @@ from typing import NoReturn
 from ._config import Config, Doc, Predicate, Server
 from ._context import (
     AsyncClient,
-    AsyncExitStack,
     Context,
     Statistics,
     WeakValueDictionary,
+    schedule_exit,
 )
-from ._stream import Response, StreamingResponse, get, stream
+from ._stream import APIRoute, Response, StreamingResponse, get, stream
 
 context = Context("context")
 

--- a/src/mahoraga/_pypi/__init__.py
+++ b/src/mahoraga/_pypi/__init__.py
@@ -16,8 +16,10 @@ __all__ = ["router"]
 
 import fastapi
 
+from mahoraga import _core
+
 from . import _packages, _simple
 
-router = fastapi.APIRouter()
+router = fastapi.APIRouter(route_class=_core.APIRoute)
 router.include_router(_packages.router, prefix="/packages")
 router.include_router(_simple.router, prefix="/simple")

--- a/src/mahoraga/_pypi/_simple.py
+++ b/src/mahoraga/_pypi/_simple.py
@@ -24,7 +24,7 @@ import kiss_headers
 
 from mahoraga import _core
 
-router = fastapi.APIRouter()
+router = fastapi.APIRouter(route_class=_core.APIRoute)
 
 
 @router.get("/{project}/")


### PR DESCRIPTION
Coroutines and generators won't do any cleanup if they had never been started, which can result in resource leak.
This PR ensures all resources are released, either by the coroutines and generators, or by direct or indirect callers of them.