### PR TITLE
Limit concurrent requests to a specific upstream

### DIFF
--- a/src/mahoraga/_cli/mahoraga.toml.jinja
+++ b/src/mahoraga/_cli/mahoraga.toml.jinja
@@ -136,13 +136,13 @@ python-build-standalone = [
 ]
 
 # Mark a mirror as backup to decrease its priority.
-# Backup mirrors are used when all non-backup mirrors are unavailable or having
-# active connections.
-backup = [
-    {%- for host in upstream.backup %}
-    "{{ host }}",
-    {%- endfor %}
-]
+# A mirror becomes backup when the number of concurrent requests reached the
+# following threshold. Backup mirrors are used when all the non-backup mirrors
+# are unavailable.
+[upstream.backup]
+{%- for key, value in upstream.backup | dictsort %}
+"{{ key }}" = {{ value }}
+{%- endfor %}
 
 # Upstream conda mirror servers.
 # The default mirrors are assumed to have all channels and support labels.

--- a/src/mahoraga/_core/_config.py
+++ b/src/mahoraga/_core/_config.py
@@ -263,6 +263,7 @@ class _PyPI(pydantic.BaseModel):
         _adapter.validate_python([
             "https://mirrors.bfsu.edu.cn/pypi/web/",
             "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/",
+            "https://mirrors.ustc.edu.cn/pypi/",
             "https://pypi.org/",
         ])
     )

--- a/src/mahoraga/_core/_config.py
+++ b/src/mahoraga/_core/_config.py
@@ -21,6 +21,7 @@ import ipaddress
 import itertools
 import os
 import sys
+from collections.abc import Iterable, Sequence
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -315,15 +316,24 @@ class _Upstream(pydantic.BaseModel, **_model_config):
         "https://releases.astral.sh/github/python-build-standalone/releases/download/",
     ])
     uv: _Uv = _Uv()
-    backup: set[str] = {
-        "anaconda.org",
-        "conda.anaconda.org",
-        "github.com",
-        "prefix.dev",
-        "pypi.org",
-        "releases.astral.sh",
-        "www.python.org",
+    backup: dict[str, pydantic.NonNegativeInt] = {
+        "anaconda.org": 0,
+        "conda.anaconda.org": 0,
+        "github.com": 0,
+        "prefix.dev": 0,
+        "pypi.org": 0,
+        "releases.astral.sh": 0,
+        "www.python.org": 0,
+        "mirrors.bfsu.edu.cn": 1,
+        "mirrors.tuna.tsinghua.edu.cn": 1,
     }
+
+    @pydantic.field_validator("backup", mode="before")
+    @classmethod
+    def compat(cls, backup: Iterable[str]) -> Iterable[str]:
+        if isinstance(backup, Sequence) and not isinstance(backup, str):
+            return dict.fromkeys(backup, 0)
+        return backup
 
 
 class Config(pydantic_settings.BaseSettings, **_model_config):

--- a/src/mahoraga/_core/_context.py
+++ b/src/mahoraga/_core/_context.py
@@ -142,17 +142,20 @@ def schedule_exit(stack: contextlib.AsyncExitStack) -> None:
 
 
 class Statistics(pydantic_settings.BaseSettings, json_file_encoding="utf-8"):
-    backup_servers: set[str]
+    backup_servers: dict[str, int]
     concurrent_requests: collections.Counter[str] = collections.Counter()
     total_seconds: collections.Counter[str] = collections.Counter()
 
     def key(self, url: str) -> tuple[bool, int, int]:
         h = httpx.URL(url).host
-        return (
-            h in self.backup_servers,
-            self.concurrent_requests[h],
-            self.total_seconds[h],
-        )
+        concurrency = self.concurrent_requests[h]
+        try:
+            limit = self.backup_servers[h]
+        except KeyError:
+            backup = False
+        else:
+            backup = concurrency >= limit
+        return backup, concurrency, self.total_seconds[h]
 
     @override
     @classmethod


### PR DESCRIPTION
Recently some mirror sites started to block our requests as we hit their rate limits, urging us to set the limits from our side.
A hard limit can be achieved by `aiohttp.TCPConnector(limit_per_host=)`, but setting different limits for different hosts is unsupported.
We use a soft limit instead: introduce a threshold of concurrent requests for a mirror to be considered as backup. This won't prohibit additional requests completely, but any other non-backup mirrors can take precedence.